### PR TITLE
fix python crash

### DIFF
--- a/gidra/proxy/kcp_socket.py
+++ b/gidra/proxy/kcp_socket.py
@@ -95,6 +95,7 @@ class KcpSocket:
         )
         self.kcp.setmtu(1200)
         self.kcp.wndsize(1024, 1024)
+        self.kcp.nodelay(1, 10, 2, 1)
 
         threading.Thread(target=self._kcp_update).start()
         threading.Thread(target=self._kcp_recv).start()

--- a/python-kcp/lkcp/kcp.py
+++ b/python-kcp/lkcp/kcp.py
@@ -1,5 +1,5 @@
 from . import core
-import sys
+import sys, threading
 
 __all__ = ["KcpObj"]
 
@@ -9,6 +9,7 @@ class KcpObj:
     def __init__(self, conv, token, callback):
         self.conv = conv
         self.token = token
+        self.mutex = threading.Lock()
 
         global i
         self.cobj = core.lkcp_create(conv, token, i, callback)
@@ -21,24 +22,41 @@ class KcpObj:
         return core.lkcp_nodelay(self.cobj, nodelay, interval, resend, nc)
 
     def check(self, current):
-        return core.lkcp_check(self.cobj, current)
+        self.mutex.acquire()
+        ret = core.lkcp_check(self.cobj, current)
+        self.mutex.release()
+        return ret
 
     def update(self, current):
+        self.mutex.acquire()
         core.lkcp_update(self.cobj, current)
+        self.mutex.release()
 
     def send(self, data):
+        self.mutex.acquire()
         if sys.version_info.major == 3 and isinstance(data, str):
             data = data.encode("UTF-8")
-        return core.lkcp_send(self.cobj, data)
+        ret = core.lkcp_send(self.cobj, data)
+        self.mutex.release()
+        return ret
 
     def input(self, data):
-        return core.lkcp_input(self.cobj, data)
+        self.mutex.acquire()
+        ret = core.lkcp_input(self.cobj, data)
+        self.mutex.release()
+        return ret
 
     def recv(self):
-        return core.lkcp_recv(self.cobj)
+        self.mutex.acquire()
+        ret = core.lkcp_recv(self.cobj)
+        self.mutex.release()
+        return ret
 
     def flush(self):
+        self.mutex.acquire()
         core.lkcp_flush(self.cobj)
+        self.mutex.release()
+
     
     def setmtu(self, mtu):
         core.lkcp_setmtu(self.cobj, mtu)


### PR DESCRIPTION
Move kcp global recv_buffer to private, and add mutex on KcpObj, nodelay on client.